### PR TITLE
Add local build instructions and dependencies

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,10 @@
+# Virtual environments
+blogenv/
+
+# Build output
+_build/
+reports/
+
+# Python cache
+__pycache__/
+*.pyc

--- a/README.md
+++ b/README.md
@@ -1,0 +1,12 @@
+# My Blog
+
+This repository contains a static site generated with Jupyter Book.
+
+To build the site locally, install dependencies and run `jupyter-book build`:
+
+```bash
+pip install -r requirements.txt
+jupyter-book build .
+```
+
+The example notebook requires `matplotlib`, which is included in the requirements.

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,2 @@
+jupyter-book
+matplotlib


### PR DESCRIPTION
## Summary
- add README with instructions for building the Jupyter Book
- track minimal Python requirements including matplotlib
- ignore env, build outputs and caches

## Testing
- `jupyter-book build .` *(fails: Couldn't find a Table of Contents file)*

------
https://chatgpt.com/codex/tasks/task_e_68597ff054f4832a956ef4474cec7f3f